### PR TITLE
feat: Add README, LICENSE, CONTRIBUTING, clean code, and add quality …

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing to YT Downloader
+
+We welcome contributions to YT Downloader! Whether you want to report a bug, suggest a feature, or submit code changes, this guide will help you get started.
+
+## Reporting Bugs
+
+If you encounter a bug, please open an issue on the [GitHub repository](https://github.com/MikeCHOKKI/yt-downloader/issues). When reporting a bug, please include:
+
+- A clear and descriptive title.
+- Steps to reproduce the bug.
+- The expected behavior and what actually happened.
+- Your environment details (OS, Node.js version, etc.).
+
+## Suggesting Features
+
+If you have an idea for a new feature or an improvement to an existing one, please open an issue on the [GitHub repository](https://github.com/MikeCHOKKI/yt-downloader/issues). Describe the feature and why you think it would be beneficial.
+
+## Submitting Pull Requests
+
+1. Fork the repository.
+2. Create a new branch for your changes:
+   ```bash
+   git checkout -b feature/your-feature-name
+   ```
+3. Make your changes and commit them with clear and descriptive messages.
+4. Push your changes to your forked repository:
+   ```bash
+   git push origin feature/your-feature-name
+   ```
+5. Open a pull request on the [GitHub repository](https://github.com/MikeCHOKKI/yt-downloader/pulls). Provide a detailed description of your changes and why they should be merged.
+
+## Sponsoring
+
+If you find YT Downloader useful and would like to support its development, you can sponsor the project via [GitHub Sponsors](https://github.com/sponsors/MikeCHOKKI). Your support is greatly appreciated!

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Ekim's
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,40 @@
+# YT Downloader
+
+YT Downloader is an interactive CLI application for downloading YouTube videos and playlists with advanced features. Unlike traditional tools, it offers an intuitive interface with interactive menus, persistent configuration management, and an enhanced downloading experience.
+
+## Features
+
+- Download individual videos or entire playlists.
+- Get information about videos and playlists (title, duration, size, etc.).
+- Configure default download options (resolution, output directory, format).
+- Interactive CLI interface with menus and prompts.
+- Persistent configuration saves your preferences.
+
+## Installation
+
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/MikeCHOKKI/yt-downloader.git
+   ```
+2. Navigate to the project directory:
+   ```bash
+   cd yt-downloader
+   ```
+3. Install dependencies:
+   ```bash
+   npm install
+   ```
+
+## Usage
+
+To start the application, run:
+
+```bash
+npm start
+```
+
+Follow the interactive prompts to download videos, playlists, or configure options.
+
+## Contributing
+
+Contributions are welcome! Please see the [CONTRIBUTING.md](CONTRIBUTING.md) file for guidelines.

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,6 +4,8 @@ export interface DownloadOptions {
   format?: string;
   verbose?: boolean;
   limit?: number;
+  audioQuality?: string;
+  videoQuality?: string;
 }
 
 export interface VideoInfo {
@@ -26,4 +28,6 @@ export interface Config {
   outputDir: string;
   format: string;
   verbose: boolean;
+  audioQuality: string;
+  videoQuality: string;
 }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -11,6 +11,8 @@ const DEFAULT_CONFIG: Config = {
   outputDir: "downloads",
   format: "mp4",
   verbose: false,
+  audioQuality: "best",
+  videoQuality: "best",
 };
 
 /**


### PR DESCRIPTION
…selection

This commit introduces several enhancements to the yt-downloader project:

- **Documentation:**
    - Added a comprehensive README.md with project overview, features, installation, and usage instructions.
    - Included an MIT LICENSE file.
    - Added a CONTRIBUTING.md file with guidelines for contributors and information on sponsoring.

- **Code Quality:**
    - Cleaned `src/index.ts` and `src/services/downloader.ts`.
    - Improved error handling consistency in `src/index.ts`.
    - Fixed a bug in `src/services/downloader.ts` where the downloaded filename was not correctly captured.

- **New Feature: Audio and Video Quality Selection:**
    - You can now specify desired video and audio quality for downloads.
    - Added prompts in `downloadVideoFlow` and `downloadPlaylistFlow` for quality selection.
    - Updated `changeDefaultOptions` to allow setting default audio/video quality.
    - `VideoDownloader` service now constructs appropriate `yt-dlp` commands based on selected quality settings (e.g., resolution for video, bitrate for audio, or "best"/"worst").
    - Configuration (`src/utils/config.ts` and `src/types/index.ts`) updated to store and manage these new quality preferences.
    - The previous `resolution` option is now marked as "(legacy)" in the UI but still considered if new quality settings are not available.